### PR TITLE
[ADD] Config option for jobrunner runjob timeout

### DIFF
--- a/queue_job/job.py
+++ b/queue_job/job.py
@@ -13,7 +13,8 @@ import odoo
 
 from .exception import (NoSuchJobError,
                         FailedJobError,
-                        RetryableJobError, JobError)
+                        RetryableJobError,
+                        JobError)
 
 
 PENDING = 'pending'

--- a/queue_job/jobrunner/runner.py
+++ b/queue_job/jobrunner/runner.py
@@ -239,7 +239,11 @@ def _async_http_get(scheme, host, port, user, password, db_name, job_uuid):
                 auth = (user, password)
             # we are not interested in the result, so we set a short timeout
             # but not too short so we trap and log hard configuration errors
-            response = session.get(url, timeout=1, auth=auth)
+            response_timeout = config.misc.get("queue_job", {}).get(
+                "runjob_response_timeout", 1
+            )
+            response_timeout = int(response_timeout)
+            response = session.get(url, timeout=response_timeout, auth=auth)
 
             # raise_for_status will result in either nothing, a Client Error
             # for HTTP Response codes between 400 and 500 or a Server Error


### PR DESCRIPTION
* Config option added to up the default of 1 second, so it can be adjusted for cases where the API call may be delayed.