### PR TITLE
[FIX] Don't start jobrunner worker when root capacity set to zero

### DIFF
--- a/queue_job/jobrunner/__init__.py
+++ b/queue_job/jobrunner/__init__.py
@@ -139,9 +139,11 @@ def threaded_stop(server):
         runner_thread = None
     return res
 
-
-server.PreforkServer.__init__ = prefork__init__
-server.PreforkServer.process_spawn = prefork_process_spawn
-server.PreforkServer.worker_pop = prefork_worker_pop
+if _is_runner_enabled():
+    server.PreforkServer.__init__ = prefork__init__
+    server.PreforkServer.process_spawn = prefork_process_spawn
+    server.PreforkServer.worker_pop = prefork_worker_pop
+elif config.get('workers', 0) > 0:
+    _logger.info("jobrunner not started, because the root channel's capacity is set to 0")
 server.ThreadedServer.start = threaded_start
 server.ThreadedServer.stop = threaded_stop


### PR DESCRIPTION
In multi-worker mode the jobrunner worker currently starts even if the capacity is zero. It doesn't run jobs but it will access them and log warnings or unrecognised channel names if not set in config.

Add a check to stop the worker even being started if it isn't needed.