### PR TITLE
[IMP] Increase buffer for jobs check in _query_requeue_dead_jobs

### DIFF
--- a/queue_job/controllers/main.py
+++ b/queue_job/controllers/main.py
@@ -54,14 +54,15 @@ class RunJobController(http.Controller):
         #       update queue_job set=state=started
         #       where state=enqueid and id=
         job.set_started()
-        job.store()
+        odoo_job_id = job.store()
         http.request.env.cr.commit()
-        job.lock()
+        job.lock(odoo_job_id)
         _logger.debug('%s started', job)
         job.perform()
         job.set_done()
         job.store()
         http.request.env.cr.commit()
+        job.unlock(odoo_job_id)
         _logger.debug('%s done', job)
 
     @http.route('/queue_job/session', type='http', auth="none")

--- a/queue_job/job.py
+++ b/queue_job/job.py
@@ -272,39 +272,30 @@ class Job(object):
             [self.uuid],
         )
 
-    def lock(self):
+    def lock(self, odoo_job_id):
         """
         Lock row of job that is being performed
         If a job cannot be locked,
         it means that the job wasn't started,
         a RetryableJobError is thrown.
         """
-        self.env.cr.execute(
-                        """
-            SELECT
-                *
-            FROM
-                queue_job_lock
-            WHERE
-                queue_job_id in (
-                    SELECT
-                        id
-                    FROM
-                        queue_job
-                    WHERE
-                        uuid = %s
-                        AND state='started'
-                )
-            FOR UPDATE
-        """,
-            [self.uuid],
-        )
+        # Try to lock the job
+        self.env.cr.execute("SELECT 1 FROM pg_locks WHERE locktype = 'advisory' AND classid = hashtext('queue_job_lock') AND objid = %s", (odoo_job_id,))
+        if self.env.cr.fetchone():
+            # Lock already exists, job may have been manually requeued or
+            # the db connection was lost during previous job execution
+            # Release the lock and set a new one
+            self.env.cr.execute("SELECT pg_advisory_unlock(hashtext('queue_job_lock'), %s)", (odoo_job_id,))
 
-        # 1 job should be locked
-        if 1 != len(self.env.cr.fetchall()):
-            raise RetryableJobError(
-                                f"Trying to lock job that wasn't started, uuid: {self.uuid}"
-            )
+        self.env.cr.execute("SELECT pg_advisory_lock(hashtext('queue_job_lock'), %s)", (odoo_job_id,))
+        self.env.cr.commit()
+
+    def unlock(self, odoo_job_id):
+        """
+        Unlock row of job that is being performed
+        """
+        self.env.cr.execute("SELECT pg_advisory_unlock(hashtext('queue_job_lock'), %s)", (odoo_job_id,))
+        self.env.cr.commit()
 
     @classmethod
     def _load_from_db_record(cls, job_db_record):
@@ -593,6 +584,7 @@ class Job(object):
                 }
             )
             self.env[self.job_model_name].sudo().create(vals)
+        return db_record.id
 
     @property
     def func_string(self):

--- a/queue_job/jobrunner/runner.py
+++ b/queue_job/jobrunner/runner.py
@@ -330,42 +330,49 @@ class Database(object):
             UPDATE
                 queue_job
             SET
-                state=(
+                state = (
                     CASE
-                        WHEN
-                            max_retries IS NOT NULL AND
-                            retry IS NOT NULL AND
-                            retry>=max_retries
+                        WHEN max_retries IS NOT NULL 
+                            AND retry IS NOT NULL 
+                            AND retry >= max_retries
                         THEN 'failed'
                         ELSE 'pending'
-                    END),
-                retry=(CASE WHEN state='started' THEN COALESCE(retry,0)+1 ELSE retry END),
-                exc_info=(
+                    END
+                ),
+                retry = (
+                    CASE 
+                        WHEN state = 'started' THEN COALESCE(retry, 0) + 1 
+                        ELSE retry 
+                    END
+                ),
+                exc_info = (
                     CASE
-                        WHEN
-                            max_retries IS NOT NULL AND
-                            retry IS NOT NULL AND
-                            retry>=max_retries
+                        WHEN max_retries IS NOT NULL 
+                            AND retry IS NOT NULL 
+                            AND retry >= max_retries
                         THEN 'Job not completed, max retries reached'
                         ELSE exc_info
-                    END)
+                    END
+                )
             WHERE
-                id in (
-                    SELECT
-                        queue_job_id
-                    FROM
-                        queue_job_lock
-                    WHERE
-                        queue_job_id in (
-                            SELECT
-                                id
-                            FROM
-                                queue_job
-                            WHERE
-                                state IN ('enqueued','started')
-                                AND date_enqueued <
-                                (now() AT TIME ZONE 'utc' - INTERVAL '10 sec')
-                        )
+                id IN (
+                    SELECT queue_job_id
+                    FROM queue_job_lock
+                    WHERE queue_job_id IN (
+                        SELECT id
+                        FROM queue_job
+                        WHERE state IN ('enqueued', 'started')
+                        AND date_enqueued < (now() AT TIME ZONE 'utc' - INTERVAL '300 sec')
+                        AND date_created < (now() AT TIME ZONE 'utc' - INTERVAL '300 sec')
+                    )
+                    -- Ignore jobs with advisory locks
+                    AND queue_job_id NOT IN (
+                        SELECT objid
+                        FROM pg_locks 
+                        WHERE locktype = 'advisory' 
+                        AND classid = hashtext('queue_job_lock')
+                    )
+                    -- Ignore jobs with row-level locks
                     FOR UPDATE SKIP LOCKED
                 )
             RETURNING uuid, state, name, method_name
@@ -563,10 +570,10 @@ class QueueJobRunner(object):
                 _logger.info("database connections ready")
                 # inner loop does the normal processing
                 while not self._stop:
-                    self.requeue_dead_jobs()
                     self.process_notifications()
                     self.run_jobs()
                     self.wait_notification()
+                    self.requeue_dead_jobs()
             except KeyboardInterrupt:
                 self.stop()
             except Exception as e:


### PR DESCRIPTION
* Move the check for dead jobs until after wait_notification
* Up check for jobs enqueued so that they have been enqueued for at
  least 5 minutes
* Don't requeue any job that isn't older than 5 minutes
* Use advisory locks for job_queue_lock so that the locks can persist
  for the session and not be lost if the transaction is committed
  at any point whilst the job is running or being marked as done
* Avoids potential for Odoo to inadvertantly requeue a job that
  is still running or has finished but not marked the job as done yet